### PR TITLE
CR-008: Fix for double cannot be converted to java.math.BigDecimal

### DIFF
--- a/openapi/components/schemas/v1/document_request.yaml
+++ b/openapi/components/schemas/v1/document_request.yaml
@@ -70,7 +70,6 @@ properties:
     format: double
     description: Exchange rate applicable to the transfer amount
     example: 1.12
-    default: 1.0
     minimum: 0.0
     exclusiveMinimum: 0.0
     multipleOf: 0.000001


### PR DESCRIPTION
## What/Why/How?

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
